### PR TITLE
update cypress/github action to v2 from v1 resolving E2E error on check

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Unit Tests
         run: yarn test --watchAll=false
       - name: E2E Tests
-        uses: cypress-io/github-action@v1
+        uses: cypress-io/github-action@v2
         with:
           start: yarn start
           wait-on: 'http://localhost:3000'


### PR DESCRIPTION
using v1 of cypress github-actions causes an error on the branch as in the screenshot.
![Screenshot_12](https://user-images.githubusercontent.com/44810632/112049365-322b1800-8b58-11eb-80d8-3032f386513a.png)

The issue was opened and addressed on cypress repo, they fixed it in v@2 and advised upgrading to prevent future issues.

issue Link: https://github.com/cypress-io/github-action/issues/206